### PR TITLE
fix(sidecar) : quarkus platform version update & graphql vulnerability fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>2.16.3.Final</quarkus.platform.version>
+        <quarkus.platform.version>3.6.4</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     </properties>


### PR DESCRIPTION
Subject:  fix(sidecar) : quarkus platform version update & graphql vulnerability fixed
Assignees: @soumyadip007 

## Issue 

A flaw was found in Quarkus. This issue occurs when receiving a request over websocket with no role-based permission specified on the GraphQL operation, Quarkus processes the request without authentication despite the endpoint being secured. This can allow an attacker to access information and functionality outside of normal granted API permissions. ([CVE Details](https://nvd.nist.gov/vuln/detail/CVE-2023-6394))


## Resolution (Reason behind the version update)

Quarkus team has resolve the [GraphQL Websocket ](https://github.com/quarkusio/quarkus/pull/36961 ) in their recent release ([Quarkus 3.5.3](https://github.com/quarkusio/quarkus/releases/tag/3.5.3)). The have also resolved few of the issues in their latest version so we're updating the Quarkus platform version to [3.6.4](https://github.com/quarkusio/quarkus/releases/tag/3.6.4).