### PR TITLE
chore(sidecar) : vertx-web replaced with reactive-routes & jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,17 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>3.0.0</version>
+                <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/io/spaship/sidecar/api/SpaUploadController.java
+++ b/src/main/java/io/spaship/sidecar/api/SpaUploadController.java
@@ -8,8 +8,8 @@ import org.jboss.resteasy.reactive.MultipartForm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.Objects;
 
 @Path("upload")

--- a/src/main/java/io/spaship/sidecar/api/SyncController.java
+++ b/src/main/java/io/spaship/sidecar/api/SyncController.java
@@ -7,8 +7,8 @@ import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/io/spaship/sidecar/config/RestConfig.java
+++ b/src/main/java/io/spaship/sidecar/config/RestConfig.java
@@ -1,7 +1,7 @@
 package io.spaship.sidecar.config;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/api")
 public class RestConfig extends Application {

--- a/src/main/java/io/spaship/sidecar/config/RestExceptionMapperConfig.java
+++ b/src/main/java/io/spaship/sidecar/config/RestExceptionMapperConfig.java
@@ -2,9 +2,9 @@ package io.spaship.sidecar.config;
 
 import io.spaship.sidecar.type.ErrorResponse;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import java.util.Objects;
 
 @Provider

--- a/src/main/java/io/spaship/sidecar/services/RequestProcessor.java
+++ b/src/main/java/io/spaship/sidecar/services/RequestProcessor.java
@@ -12,8 +12,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/main/java/io/spaship/sidecar/sync/SyncService.java
+++ b/src/main/java/io/spaship/sidecar/sync/SyncService.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.event.Observes;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;


### PR DESCRIPTION
Subject:  chore(sidecar) : vertx-web replaced with reactive-routes & jakarta
Assignees: @soumyadip007 

## Reasons behind the change 

Quarkus has discontinued support for [quarkus-vertx-web](https://mvnrepository.com/artifact/io.quarkus/quarkus-vertx-web) after the release of 3.0.0. They have moved the artifact to quarkus-reactive-routes, which is compatible with the latest Quarkus [version 3.6.0](https://mvnrepository.com/artifact/io.quarkus/quarkus-reactive-routes). 

Additionally, Jakarta has been imported to replace javax. After removing quarkus-vertx-web, it started throwing an error due to the import not being found. Therefore, Jakarta was imported to resolve the issue.

## Resolutions

1. quarkus-vertx-web is replaced with quarkus-reactive-routes (3.6.0).
2. jakarta added to the dependency, and javax replaced with jakarta.

## Build Status (Success)

```
[INFO] --- quarkus-maven-plugin:3.6.4:build (default) @ spaship-sidecar ---
[INFO] [io.quarkus.deployment.QuarkusAugmentor] Quarkus augmentation completed in 2218ms
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  51.095 s
[INFO] Finished at: 2024-01-09T20:43:54+05:30
[INFO] ------------------------------------------------------------------------
```