### PR TITLE
feat(sidecar) : quarkus platform updated, vertx-web replaced with reactive-routes & jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,17 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-vertx-web</artifactId>
+            <artifactId>quarkus-reactive-routes</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>3.0.0</version>
+                <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/src/main/java/io/spaship/sidecar/api/SpaUploadController.java
+++ b/src/main/java/io/spaship/sidecar/api/SpaUploadController.java
@@ -8,8 +8,8 @@ import org.jboss.resteasy.reactive.MultipartForm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.Objects;
 
 @Path("upload")

--- a/src/main/java/io/spaship/sidecar/api/SyncController.java
+++ b/src/main/java/io/spaship/sidecar/api/SyncController.java
@@ -7,8 +7,8 @@ import io.vertx.core.json.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/io/spaship/sidecar/config/RestConfig.java
+++ b/src/main/java/io/spaship/sidecar/config/RestConfig.java
@@ -1,7 +1,7 @@
 package io.spaship.sidecar.config;
 
-import javax.ws.rs.ApplicationPath;
-import javax.ws.rs.core.Application;
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
 
 @ApplicationPath("/api")
 public class RestConfig extends Application {

--- a/src/main/java/io/spaship/sidecar/config/RestExceptionMapperConfig.java
+++ b/src/main/java/io/spaship/sidecar/config/RestExceptionMapperConfig.java
@@ -2,9 +2,9 @@ package io.spaship.sidecar.config;
 
 import io.spaship.sidecar.type.ErrorResponse;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import java.util.Objects;
 
 @Provider

--- a/src/main/java/io/spaship/sidecar/services/RequestProcessor.java
+++ b/src/main/java/io/spaship/sidecar/services/RequestProcessor.java
@@ -12,8 +12,8 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;

--- a/src/main/java/io/spaship/sidecar/sync/SyncService.java
+++ b/src/main/java/io/spaship/sidecar/sync/SyncService.java
@@ -8,7 +8,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.event.Observes;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;


### PR DESCRIPTION
Hi @arkaprovob ,

These changes are already verified on the `fix/pod-vulnerability` branch, please merge it during the release. 

1. [chore(sidecar) : vertx-web replaced with reactive-routes & jakarta #18](https://github.com/spaship/sidecar/pull/18)
2. [fix(sidecar) : quarkus platform version update & graphql vulnerability fixed #17](https://github.com/spaship/sidecar/pull/17)
